### PR TITLE
Add gcatch and ccatch tests (complex expressions)

### DIFF
--- a/test.c
+++ b/test.c
@@ -179,6 +179,40 @@ static void test06(void)
         && !after_finally);
 }
 
+/* gcatch, complex expression (return val of assignment) */
+static void test07(void)
+{
+    int x = 1;
+
+    reset();
+
+    try {
+        throw(foo);
+    }
+    gcatch(foo, x = 0 ? 0 : 1) {
+        caught = 1;
+    } endtry
+
+    assert(caught);
+}
+
+/* ccatch, complex expression (return val of assignment) */
+static void test08(void)
+{
+    int x = 1;
+
+    reset();
+
+    try {
+      throw(foo);
+    }
+    ccatch(x = 0 ? 0 : 1) {
+        caught = 1;
+    } endtry
+
+    assert(caught);
+}
+
 int main(void)
 {
     test01(); printf("1"); fflush(stdout);
@@ -187,6 +221,8 @@ int main(void)
     test04(); printf("4"); fflush(stdout);
     test05(); printf("5"); fflush(stdout);
     test06(); printf("6"); fflush(stdout);
+    test07(); printf("7"); fflush(stdout);
+    test08(); printf("8"); fflush(stdout);
     printf("\nRocket Crash: All tests passed.\n");
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
* this tests for the issues commit 65a8ffd3b7bfca76fe3efdcf8308ce6a3b863b3f
  fixed
    
As is common with macro bugs, these tests won't fail with the above commit
reverted (or in a future regression), because they don't even manage to
compile. If the user always compiles their code with strong compiler warning
flags it would warn about these kind of usage syntaxes anyway (i.e.
suggesting to add parentheses around the assignment in this case), but for
users who won't use such compiler flags (or find even weirder edge-cases
where a properly protected parameter still fails) it's useful to have these
tests so this behaviour doesn't regress.